### PR TITLE
Gentoo OpenRC init and conf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,1 @@
-armills-overlay
-===============
-
-My personal gentoo overlay
-
-To add this overlay, use the following commands:
-
-    sudo curl https://raw.githubusercontent.com/armills/overlay/master/repo.conf -o /etc/portage/repos.conf/armills.conf
-    sudo emaint sync -r armills
+This is a fork of [armills-overlay](https://github.com/armills/overlay) I made in order to tweak the `/etc/init.d` and `/etc/conf.d` files for the `media-sound/snapclient` ebuild.

--- a/media-sound/snapcast/files/snapclient.confd
+++ b/media-sound/snapcast/files/snapclient.confd
@@ -1,0 +1,1 @@
+SNAPCLIENT_OPTS="-d -h 192.168.1.21 -p 1704"

--- a/media-sound/snapcast/files/snapclient.confd
+++ b/media-sound/snapcast/files/snapclient.confd
@@ -1,1 +1,1 @@
-SNAPCLIENT_OPTS="-d -h 192.168.1.21 -p 1704"
+SNAPCLIENT_OPTS="-d -h 192.168.1.21 -p 1704 --user snapclient:audio"

--- a/media-sound/snapcast/files/snapclient.initd
+++ b/media-sound/snapcast/files/snapclient.initd
@@ -1,0 +1,28 @@
+#!/sbin/openrc-run
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+: CFGFILE=${CFGFILE:=/etc/default/snapclient}
+
+depend() {
+#  (Dependency information)
+   need net
+   config ${CFGFILE}
+}
+
+start() {
+#  (Commands necessary to start the service)
+   ebegin "Starting snapclient"
+   start-stop-daemon --start --exec /usr/bin/snapclient  \
+		     --pidfile /var/run/snapclient.pid \
+		     -- ${SNAPCLIENT_OPTS}
+   eend $?
+}
+
+stop() {
+#  (Commands necessary to stop the service)
+   ebegin "Stopping snapclient"
+   start-stop-daemon --stop --exec /usr/bin/snapclient \
+		     --pidfile /var/run/snapclient.pid --quiet
+   eend $?
+}

--- a/media-sound/snapcast/files/snapclient.initd
+++ b/media-sound/snapcast/files/snapclient.initd
@@ -14,7 +14,7 @@ start() {
 #  (Commands necessary to start the service)
    ebegin "Starting snapclient"
    start-stop-daemon --start --exec /usr/bin/snapclient  \
-		     --pidfile /var/run/snapclient.pid \
+		     --pidfile /var/run/snapclient/pid \
 		     -- ${SNAPCLIENT_OPTS}
    eend $?
 }
@@ -23,6 +23,6 @@ stop() {
 #  (Commands necessary to stop the service)
    ebegin "Stopping snapclient"
    start-stop-daemon --stop --exec /usr/bin/snapclient \
-		     --pidfile /var/run/snapclient.pid --quiet
+		     --pidfile /var/run/snapclient/pid --quiet
    eend $?
 }

--- a/media-sound/snapcast/files/snapserver.confd
+++ b/media-sound/snapcast/files/snapserver.confd
@@ -1,0 +1,1 @@
+SNAPSERVER_OPTS="-d --user snapserver:audio"

--- a/media-sound/snapcast/files/snapserver.initd
+++ b/media-sound/snapcast/files/snapserver.initd
@@ -1,0 +1,28 @@
+#!/sbin/openrc-run
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+: CFGFILE=${CFGFILE:=/etc/default/snapserver}
+
+depend() {
+#  (Dependency information)
+   need net
+   config ${CFGFILE}
+}
+
+start() {
+#  (Commands necessary to start the service)
+   ebegin "Starting snapserver"
+   start-stop-daemon --start --exec /usr/bin/snapserver \ \
+		     --pidfile /var/run/snapserver/pid \
+		     -- ${SNAPSERVER_OPTS}
+   eend $?
+}
+
+stop() {
+#  (Commands necessary to stop the service)
+   ebegin "Stopping snapserver"
+   start-stop-daemon --stop --exec /usr/bin/snapserver \
+		     --pidfile /var/run/snapserver/pid
+   eend $?
+}

--- a/media-sound/snapcast/snapcast-9999.ebuild
+++ b/media-sound/snapcast/snapcast-9999.ebuild
@@ -46,7 +46,8 @@ src_install() {
 
 		emake DESTDIR="${D}" "install${component}"
 
-		newinitd "${S}/${component}/debian/snap${component}.init" "snap${component}"
+		newinitd "${FILESDIR}/snap${component}.initd" "snap${component}"
+		newconfd "${FILESDIR}/snap${component}.confd" "snap${component}"
 		systemd_dounit "${S}/${component}/debian/snap${component}.service"
 
 		insinto "/etc/default"

--- a/media-sound/snapcast/snapcast-9999.ebuild
+++ b/media-sound/snapcast/snapcast-9999.ebuild
@@ -1,5 +1,6 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+# $id$
 
 EAPI=6
 
@@ -26,7 +27,9 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 pkg_setup() {
-	enewuser snapserver -1 -1 -1 "audio"
+	for component in server client; do
+		enewuser snap${component} -1 -1 -1 "audio"
+	done
 }
 
 src_compile() {

--- a/media-sound/snapcast/snapcast-9999.ebuild
+++ b/media-sound/snapcast/snapcast-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 
@@ -25,6 +24,10 @@ DEPEND="
 	net-dns/avahi"
 
 RDEPEND="${DEPEND}"
+
+pkg_setup() {
+	enewuser snapserver -1 -1 -1 "audio"
+}
 
 src_compile() {
 	# Override the strip binary to : to prevent stripping debug symbols


### PR DESCRIPTION
Hi,

First attempt at some conf and init files, seems to work here.

* Created and tested init and conf files
* Modified `snapcast-9999.ebuild` to install these
* Re-installed locally and install completes, places the new init files and conf files in the right location
* Init script for client (`/etc/init.d/snapclient start`) works and it picks up \o/ (not tested server as server is on another system).

Questions/issues

* Attempted to create user `snapserver` to run server daemon as (seems to be the way it runs under systemd on the ArchLinux I'm running as).  This doesn't seem to have been executed (i.e. no `snapserver` entry in `/etc/group`).  Unsure why this might be.  As a result snapserver runs as root (possibly insecure) and once the user is created I'll need to update `/etc/conf.d/snapserver` with the `--user snapserver`.
* Unsure if snapclient should also have a user created and run?
* For now I created `/etc/conf.d/snapclient` with `-h 192.168.1.21` which is the server on my home network.  I was unsure what a sane setting would be for the ebuild, its going to differ for everyone.  One thought was to that is should perhaps be set to `-h 127.0.0.1` so that the client runs on the same system as the server, but was unsure.

Comments/thoughts/feedback very welcome, I've only ever written a couple of ebuilds in the past (for obscure statistical genetics software) so I'm very new to this.  Used the [Gentoo Dev Handbook](https://devmanual.gentoo.org/) for guidance on the things I was trying to do, but since its too much to read and digest in one go I may well have missed things.

I'll try testing server on Gentoo later today, got some OpenWRT VPN configuration I want to get done first today though).

Also this is my first real attempt at pull requests, if I've cocked anything up please let me know so I can learna nd improve.

Thanks